### PR TITLE
Add remember_per_file_suffix option

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,8 @@
 globals = {
 	"ya",
 	"cx",
+  "fs",
+  "Url",
 }
 ignore = {
 	".*self",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `remember_per_file_suffix` option. Default to `false`.
+
 ## 0.1.2 - 2025-09-19
 
 - Add `notify_on_switch` option. Default to `false`.

--- a/README.md
+++ b/README.md
@@ -33,18 +33,20 @@ prepend_keymap = [
 ]
 ```
 
-### Example setup
+### Example setup (optional)
 
-| Option             | Default | Description                                                    |
-| ------------------ | ------- | -------------------------------------------------------------- |
-| `notify_on_switch` | `false` | Whether to show a notification when the previewer is switched. |
-| `aliases`          | `{}`    | See "Use cases" for examples on how to use it.                 |
+| Option                     | Default | Description                                                                                                                                                                                                                  |
+| -------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `notify_on_switch`         | `false` | Whether to show a notification when the previewer is switched.                                                                                                                                                               |
+| `remember_per_file_suffix` | `false` | If `false`, the current previewer is remembered per file (per session). If `true`, the current previewer is remembered per suffix, so e.g. each JSON file will be previewed with the last selected previewer for JSON files. |
+| `aliases`                  | `{}`    | See "Use cases" for examples on how to use it.                                                                                                                                                                               |
 
 > NOTE: Setup is only required if you want to change from the defaults.
 
 ```lua
 require("mux"):setup({
   notify_on_switch = true, -- Default: false
+  remember_per_file_suffix = true, -- Default: false
   aliases = {}, -- Default: {}
 })
 ```


### PR DESCRIPTION
Default to `false`.

If `false`, the current previewer is remembered per file (per session). If `true`, the current previewer is remembered per suffix, so e.g. each JSON file will be previewed with the last selected previewer for JSON files.