### PR TITLE
Remove LS_COLORS from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ require("mux"):setup({
 Explanations:
 
 - `cd` before `eza` makes sure that the root does not contain the full path
-- `LS_COLORS` paints executables green, like yazi
-- Or use an [eza theme](https://github.com/eza-community/eza-themes) that aligns with your [yazi flavor](https://github.com/yazi-rs/flavors).
+- Make sure to use an [eza theme](https://github.com/eza-community/eza-themes) that aligns with your [yazi flavor](https://github.com/yazi-rs/flavors).
 
 ```lua
 -- init.lua
@@ -76,25 +75,25 @@ require("mux"):setup({
 		eza_tree_1 = {
 			previewer = "piper",
 			args = {
-				'cd "$1" && LS_COLORS="ex=32" eza --oneline --tree --level 1 --color=always --icons=always --group-directories-first --no-quotes .',
+				'cd "$1" && eza --oneline --tree --level 1 --color=always --icons=always --group-directories-first --no-quotes .',
 			},
 		},
 		eza_tree_2 = {
 			previewer = "piper",
 			args = {
-				'cd "$1" && LS_COLORS="ex=32" eza --oneline --tree --level 2 --color=always --icons=always --group-directories-first --no-quotes .',
+				'cd "$1" && eza --oneline --tree --level 2 --color=always --icons=always --group-directories-first --no-quotes .',
 			},
 		},
 		eza_tree_3 = {
 			previewer = "piper",
 			args = {
-				'cd "$1" && LS_COLORS="ex=32" eza --oneline --tree --level 3 --color=always --icons=always --group-directories-first --no-quotes .',
+				'cd "$1" && eza --oneline --tree --level 3 --color=always --icons=always --group-directories-first --no-quotes .',
 			},
 		},
 		eza_tree_4 = {
 			previewer = "piper",
 			args = {
-				'cd "$1" && LS_COLORS="ex=32" eza --oneline --tree --level 4 --color=always --icons=always --group-directories-first --no-quotes .',
+				'cd "$1" && eza --oneline --tree --level 4 --color=always --icons=always --group-directories-first --no-quotes .',
 			},
 		},
 	},


### PR DESCRIPTION
It depends on the respective terminal colors. It's better to align the Yazi and eza themes.